### PR TITLE
Add support for Lumen

### DIFF
--- a/src/OneSignalServiceProvider.php
+++ b/src/OneSignalServiceProvider.php
@@ -14,8 +14,14 @@ class OneSignalServiceProvider extends ServiceProvider
     public function boot()
     {
         $configPath = __DIR__ . '/../config/onesignal.php';
-        $this->publishes([$configPath => config_path('onesignal.php')]);
-        $this->mergeConfigFrom($configPath, 'onesignal');
+        $app = $this->app;
+        
+        if (class_exists('Illuminate\Foundation\Application') && $app instanceof LaravelApplication && $app->runningInConsole()) {
+            $this->publishes([$configPath => config_path('onesignal.php')]);
+            $this->mergeConfigFrom($configPath, 'onesignal');
+        } else if ( class_exists('Laravel\Lumen\Application', false) ) {
+            $app->configure('onesignal');
+        }
     }
 
     /**


### PR DESCRIPTION
Changes to boot() provide support for Lumen, where original version breaks on install, since config_path() isn't available by default in Lumen