### PR TITLE
Support multi app_id, fixes #25, fixes #2

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -188,8 +188,10 @@ class OneSignalClient
         $this->requiresAuth();
         $this->usesJSON();
 
-        // Make sure to use app_id
-        $parameters['app_id'] = $this->appId;
+        // if there is no `app_id` in params so use the default one
+        if (! isset($parameters['app_id']) ) {
+            $parameters['app_id'] = $this->appId;
+        }
 
         // Make sure to use included_segments
         if (empty($parameters['included_segments']) && empty($parameters['include_player_ids'])) {


### PR DESCRIPTION
Hi,

I have a project that should support multi app_id, for that I added this function :)

I tested this code and it works fine :
```
OneSignal::sendNotificationCustom(
        [
            'app_id' => config('onesignal.app_id'), # you can put another key
            'contents' => [
                "en" => 'Cool works : ' . date('H:i:s')
            ],
            'included_segments' => ['All']

        ]
    )
```