### PR TITLE
Allow array of userIds to be passed instead of just a single userId

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -96,7 +96,7 @@ class OneSignalClient
         $params = array(
             'app_id' => $this->appId,
             'contents' => $contents,
-            'include_player_ids' => array($userId)
+            'include_player_ids' => is_array($userId) ? $userId : array($userId)
         );
 
         if (isset($url)) {


### PR DESCRIPTION
Currently only a single "player_id" can be passed to sendNotificationToUser(). This pull request will allow either a single id or an array of ids.