### PR TITLE
Added a method to cancel the scheduled OneSignal notifications

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -256,6 +256,16 @@ class OneSignalClient
         $this->sendNotificationCustom($params);
     }
 
+    public function deleteNotification($notificationId, $appId = null) {
+        $this->requiresAuth();
+
+        if(!$appId)
+            $appId = $this->appId;
+        $notificationCancelNode = "/$notificationId?app_id=$this->appId";
+        return $this->delete(self::ENDPOINT_NOTIFICATIONS . $notificationCancelNode);
+
+    }
+
     /**
      * Send a notification with custom parameters defined in
      * https://documentation.onesignal.com/reference#section-example-code-create-notification
@@ -360,5 +370,13 @@ class OneSignalClient
 
     public function get($endPoint) {
         return $this->client->get(self::API_URL . $endPoint, $this->headers);
+    }
+
+    public function delete($endPoint) {
+        if($this->requestAsync === true) {
+            $promise = $this->client->deleteAsync(self::API_URL . $endPoint, $this->headers);
+            return (is_callable($this->requestCallback) ? $promise->then($this->requestCallback) : $promise);
+        }
+        return $this->client->delete(self::API_URL . $endPoint, $this->headers);
     }
 }


### PR DESCRIPTION
Notification can be cancelled by passing the ID of it. Delete method is also added as it requires a DELETE HTTP method to cancel a notification