### PR TITLE
Adding new API methods

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -303,6 +303,29 @@ class OneSignalClient
         return $this->get(self::ENDPOINT_NOTIFICATIONS . '/'.$notification_id . '?app_id='.$app_id);
     }
 
+    public function getNotifications($app_id = null, $limit = null, $offset = null) {
+        $this->requiresAuth();
+        $this->usesJSON();
+
+        $endpoint = self::ENDPOINT_NOTIFICATIONS;
+        
+        if(!$app_id) {
+            $app_id = $this->appId;
+        }
+
+        $endpoint.='?app_id='.$app_id;
+
+        if($limit) {
+            $endpoint.="&limit=".$limit;
+        }
+
+        if($offset) {
+            $endpoint.="&offset=".$$offset;
+        }
+
+        return $this->get($endpoint);
+    }
+
     public function getApp($app_id = null) {
         $this->requiresUserAuth();
         $this->usesJSON();

--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -367,6 +367,16 @@ class OneSignalClient
         return $this->sendPlayer($parameters, 'PUT', self::ENDPOINT_PLAYERS . '/' . $parameters['id']);
     }
 
+    public function requestPlayersCSV($app_id = null, Array $parameters = null) {
+        $this->requiresAuth();
+        $this->usesJSON();
+
+        $endpoint = self::ENDPOINT_PLAYERS."/csv_export?";
+        $endpoint .= "app_id" . $app_id?$app_id:$this->appId;
+
+        return $this->sendPlayer($parameters, 'POST', $endpoint);
+    }
+
     /**
      * Create or update a by $method value
      *

--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -71,6 +71,10 @@ class OneSignalClient
         $this->headers['headers']['Authorization'] = 'Basic '.$this->restApiKey;
     }
 
+    private function requiresUserAuth() {
+        $this->headers['headers']['Authorization'] = 'Basic '.$this->userAuthKey;
+    }
+
     private function usesJSON() {
         $this->headers['headers']['Content-Type'] = 'application/json';
     }
@@ -300,7 +304,7 @@ class OneSignalClient
     }
 
     public function getApp($app_id = null) {
-        $this->requiresAuth();
+        $this->requiresUserAuth();
         $this->usesJSON();
 
         if(!$app_id)
@@ -310,7 +314,7 @@ class OneSignalClient
     }
 
     public function getApps() {
-        $this->requiresAuth();
+        $this->requiresUserAuth();
         $this->usesJSON();
 
         return $this->get(self::ENDPOINT_APPS);

--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -10,6 +10,7 @@ class OneSignalClient
 
     const ENDPOINT_NOTIFICATIONS = "/notifications";
     const ENDPOINT_PLAYERS = "/players";
+    const ENDPOINT_APPS = "/apps";
 
     protected $client;
     protected $headers;
@@ -296,6 +297,23 @@ class OneSignalClient
             $app_id = $this->appId;
 
         return $this->get(self::ENDPOINT_NOTIFICATIONS . '/'.$notification_id . '?app_id='.$app_id);
+    }
+
+    public function getApp($app_id = null) {
+        $this->requiresAuth();
+        $this->usesJSON();
+
+        if(!$app_id)
+            $app_id = $this->appId;
+
+        return $this->get(self::ENDPOINT_APPS . '/'.$app_id);
+    }
+
+    public function getApps() {
+        $this->requiresAuth();
+        $this->usesJSON();
+
+        return $this->get(self::ENDPOINT_APPS);
     }
 
     /**


### PR DESCRIPTION
Adding the following methods to OneSignalClient:

- requiresUserAuth to put userauth key in requests
- [getApp](https://documentation.onesignal.com/reference#view-an-app) / [getApps](https://documentation.onesignal.com/reference#view-apps-apps) 
- [getNotifications](https://documentation.onesignal.com/reference#view-notifications)
- [requestPlayersCSV](https://documentation.onesignal.com/reference#csv-export)