### PR TITLE
Add 5.5 AutoDiscover support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ composer require berkayk/onesignal-laravel
 
 Aftwards, run `composer update` from your command line.
 
+**You only need to do the following if your Laravel version is below 5.5**:
+
 Then, update `config/app.php` by adding an entry for the service provider.
 
 ```php

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,16 @@
       "Berkayk\\OneSignal\\": "src/"
     }
   },
+  "extra": {
+    "laravel": {
+      "providers": [
+        "Berkayk\\OneSignal\\OneSignalServiceProvider"
+      ],
+      "aliases": {
+        "OneSignal": "Berkayk\\OneSignal\\OneSignalFacade"
+      }
+    }
+  },
   "license": "MIT",
   "authors": [
     {


### PR DESCRIPTION
This PR allows everyone on Laravel >= 5.5 to skip the part where you need to put the Facade Alias and Serviceprovider in your `app.php` File.