### PR TITLE
Alias the 'onesignal' service

### DIFF
--- a/src/OneSignalServiceProvider.php
+++ b/src/OneSignalServiceProvider.php
@@ -40,11 +40,11 @@ class OneSignalServiceProvider extends ServiceProvider
 
             return $client;
         });
+
+        $this->app->alias('onesignal', 'Berkayk\OneSignal\OneSignalClient');
     }
 
     public function provides() {
         return ['onesignal'];
     }
-
-
 }


### PR DESCRIPTION
This will allow the Laravel container to autowire services which have a dependency to the `Berkayk\OneSignal\OneSignalClient` without requiring use of the facade, `app()` helper, or other types of service locator based code.

This PR fixes issue #84