### PR TITLE
Improves compatibility with Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
     "php": ">=5.4.0",
     "guzzlehttp/guzzle": "^6.2",
     "illuminate/support": "4.*|5.*|6.*|7.*",
-    "symfony/psr-http-message-bridge": "1.*"
+    "symfony/psr-http-message-bridge": "1.*|2.*"
   },
   "require-dev": {
     "vlucas/phpdotenv": "^2.2"


### PR DESCRIPTION
Some libraries from official Laravel family do require **symfony/psr-http-message-bridge** ^2, therefore this change is necessary.