### PR TITLE
add laravel 8 compatability by upgrading guzzle to ^7.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "library",
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^6.2",
+    "guzzlehttp/guzzle": "^7.0.1",
     "illuminate/support": "4.*|5.*|6.*|7.*",
     "symfony/psr-http-message-bridge": "1.*|2.*"
   },

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "require": {
     "php": ">=5.4.0",
-    "guzzlehttp/guzzle": "^7.0.1",
-    "illuminate/support": "4.*|5.*|6.*|7.*",
+    "guzzlehttp/guzzle": "^6.2|^7.0.1",
+    "illuminate/support": "~5.5||~6.0||~7.0||~8.0",
     "symfony/psr-http-message-bridge": "1.*|2.*"
   },
   "require-dev": {


### PR DESCRIPTION
It does as the title suggests: updates guzzle to ^7.0.1 to support the new laravel 8 that is now released.