### PR TITLE
Allow use of dotenv variables in the package config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,12 @@ your OneSignal authorization keys.
 
 ## Configuration
 
-You need to fill in `onesignal.php` file that is found in your applications `config` directory.
-`app_id` is your *OneSignal App ID* and `rest_api_key` is your *REST API Key*.
+You need to fill in your OneSignal *App ID* and *REST API Key* inside your
+.env file like this:
+```
+ONESIGNAL_APP_ID=xxxxxxxxxxxxxxxxxxxx
+ONESIGNAL_REST_API_KEY=xxxxxxxxxxxxxxxxxx
+```
 
 ## Usage
 

--- a/config/onesignal.php
+++ b/config/onesignal.php
@@ -8,7 +8,7 @@ return array(
 	|
 	|
 	*/
-    'app_id' => 'YOUR-APP-ID-HERE',
+    'app_id' => env('ONESIGNAL_APP_ID'),
 
     /*
 	|--------------------------------------------------------------------------
@@ -18,6 +18,6 @@ return array(
     |
 	|
 	*/
-    'rest_api_key' => 'YOUR-REST-API-KEY-HERE',
-    'user_auth_key' => 'YOUR-USER-AUTH-KEY'
+    'rest_api_key' => env('ONESIGNAL_REST_API_KEY'),
+    'user_auth_key' => env('USER_AUTH_KEY')
 );


### PR DESCRIPTION
This PR introduce the use of dotenv variables inside the config file instead of hardcoding it.
 - Use dotenv variables in the config file
 - Update package configuration guide on the readme file
 - Update package publish command on the readme file
