### PR TITLE
Lumen didn't detect the alias in the facade.

### DIFF
--- a/src/OneSignalFacade.php
+++ b/src/OneSignalFacade.php
@@ -7,7 +7,7 @@ use Illuminate\Support\Facades\Facade;
 class OneSignalFacade extends Facade {
 
     protected static function getFacadeAccessor() {
-        return 'onesignal';
+        return OneSignalClient::class;
     }
 
 }


### PR DESCRIPTION
Lumen didn't detect the alias in the facade, thus changed the facade from the alias to OneSignalClient class.

