### PR TITLE
Add option to control timeout of the Guzzle Client

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You need to fill in your OneSignal *App ID* and *REST API Key* inside your
 ONESIGNAL_APP_ID=xxxxxxxxxxxxxxxxxxxx
 ONESIGNAL_REST_API_KEY=xxxxxxxxxxxxxxxxxx
 ```
-You can control timeout of the Guzzle client used by OnesignalClient by adding following into your .env file
+You can control timeout of the Guzzle client used by OneSignalClient by adding following into your .env file
 ```
 ONESIGNAL_GUZZLE_CLIENT_TIMEOUT=integer_value
 ```

--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ You need to fill in your OneSignal *App ID* and *REST API Key* inside your
 ONESIGNAL_APP_ID=xxxxxxxxxxxxxxxxxxxx
 ONESIGNAL_REST_API_KEY=xxxxxxxxxxxxxxxxxx
 ```
+You can control timeout of the Guzzle client used by OnesignalClient by adding following into your .env file
+```
+ONESIGNAL_GUZZLE_CLIENT_TIMEOUT=integer_value
+```
+This param is useful when you are planning to send push notification via [Laravel queues](https://divinglaravel.com/always-set-a-timeout-for-guzzle-requests-inside-a-queued-job) 
 
 ## Usage
 

--- a/config/onesignal.php
+++ b/config/onesignal.php
@@ -19,5 +19,15 @@ return array(
 	|
 	*/
     'rest_api_key' => env('ONESIGNAL_REST_API_KEY'),
-    'user_auth_key' => env('USER_AUTH_KEY')
+    'user_auth_key' => env('USER_AUTH_KEY'),
+
+    /*
+	|--------------------------------------------------------------------------
+	| Guzzle Timeout
+	|--------------------------------------------------------------------------
+	|
+    |
+	|
+	*/
+    'guzzle_client_timeout' => env('ONESIGNAL_GUZZLE_CLIENT_TIMEOUT', 0),
 );

--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -69,7 +69,13 @@ class OneSignalClient
         return $this;
     }
 
-    public function __construct($appId, $restApiKey, $userAuthKey)
+    /**
+     * @param $appId
+     * @param $restApiKey
+     * @param $userAuthKey
+     * @param int $guzzleClientTimeout
+     */
+    public function __construct($appId, $restApiKey, $userAuthKey, $guzzleClientTimeout = 0)
     {
         $this->appId = $appId;
         $this->restApiKey = $restApiKey;
@@ -77,6 +83,7 @@ class OneSignalClient
 
         $this->client = new Client([
             'handler' => $this->createGuzzleHandler(),
+            'timeout' => $guzzleClientTimeout,
         ]);
         $this->headers = ['headers' => []];
         $this->additionalParams = [];

--- a/src/OneSignalServiceProvider.php
+++ b/src/OneSignalServiceProvider.php
@@ -36,9 +36,7 @@ class OneSignalServiceProvider extends ServiceProvider
                 $config = $app['config']['onesignal'] ?: $app['config']['onesignal::config'];
             }
 
-            $client = new OneSignalClient($config['app_id'], $config['rest_api_key'], $config['user_auth_key']);
-
-            return $client;
+            return new OneSignalClient($config['app_id'], $config['rest_api_key'], $config['user_auth_key'] , $config['guzzle_client_timeout']);
         });
 
         $this->app->alias('onesignal', 'Berkayk\OneSignal\OneSignalClient');


### PR DESCRIPTION
You should  be able to control the timeout of the Guzzle Client when you are sending push notifications using Laravel queues to prevent worker getting stuck.
More in this  [article](https://divinglaravel.com/always-set-a-timeout-for-guzzle-requests-inside-a-queued-job).