### PR TITLE
Ignore included_segments if include_external_user_ids is filled

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -381,7 +381,7 @@ class OneSignalClient
         }
 
         // Make sure to use included_segments
-        if (empty($parameters['included_segments']) && empty($parameters['include_player_ids'])) {
+        if (empty($parameters['included_segments']) && empty($parameters['include_player_ids']) && empty('include_external_user_ids')) {
             $parameters['included_segments'] = ['All'];
         }
 


### PR DESCRIPTION
### Issue

`include_external_user_ids` filled with 5 targets, but the message was delivered to all users.
 
![Captura de tela de 2022-03-22 21-16-15](https://user-images.githubusercontent.com/30150045/159597493-dbb8e13b-ae0b-4c22-a1e5-b1c69ba142f3.png)

### Changes

- [x] Ignore segments if `include_external_user_ids` is filled

```
--- "include_external_user_ids":[...], "included_segments":["All"]}
+++ "include_external_user_ids":[...]}
```