### PR TITLE
Add `ConnectException` as a valid type in retry middleware

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -91,7 +91,7 @@ class OneSignalClient
 
     private function createGuzzleHandler() {
         return tap(HandlerStack::create(new CurlHandler()), function (HandlerStack $handlerStack) {
-            $handlerStack->push(Middleware::retry(function ($retries, Psr7Request $request, Psr7Response $response = null, RequestException $exception = null) {
+            $handlerStack->push(Middleware::retry(function ($retries, Psr7Request $request, Psr7Response $response = null, RequestException|ConnectException $exception = null) {
                 if ($retries >= $this->maxRetries) {
                     return false;
                 }


### PR DESCRIPTION
We've seen failures like `Berkayk\OneSignal\OneSignalClient::Berkayk\OneSignal\{closure}(): Argument #4 ($exception) must be of type ?GuzzleHttp\Exception\RequestException, GuzzleHttp\Exception\ConnectException given` a few times in production. This should fix that issue.