### PR TITLE
sendNotificationCustom is checking empty('include_external_user_ids')

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -388,7 +388,7 @@ class OneSignalClient
         }
 
         // Make sure to use included_segments
-        if (empty($parameters['included_segments']) && empty($parameters['include_player_ids']) && empty('include_external_user_ids')) {
+        if (empty($parameters['included_segments']) && empty($parameters['include_player_ids']) && empty($parameters['include_external_user_ids'])) {
             $parameters['included_segments'] = ['All'];
         }
 


### PR DESCRIPTION
On line 391:OneSignalClient The issue is that you are using the empty() function on a string literal 'include_external_user_ids' instead of a variable. 