### PR TITLE
 Removing a double "$" in a offset variable

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -427,7 +427,7 @@ class OneSignalClient
         }
 
         if($offset) {
-            $endpoint.="&offset=".$$offset;
+            $endpoint.="&offset=".$offset;
         }
 
         return $this->get($endpoint);


### PR DESCRIPTION
Solution to issue [#189](https://github.com/berkayk/laravel-onesignal/issues/189)