### PR TITLE
Added "channel_for_external_user_ids" to avoid delivery channel error.

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -230,6 +230,11 @@ class OneSignalClient
             );
         }
 
+        // Make sure to select channel as "Push" with parameter "channel_for_external_user_ids"
+        if (!isset($params['channel_for_external_user_ids'])) {
+            $params['channel_for_external_user_ids'] = "push";
+        }
+
         $this->sendNotificationCustom($params);
     }
     public function sendNotificationUsingTags($message, $tags, $url = null, $data = null, $buttons = null, $schedule = null, $headings = null, $subtitle = null) {


### PR DESCRIPTION
Resolved an urgent issue of Client error for method "sendNotificationToExternalUser" @berkayk/laravel-onesignal
`POST https://onesignal.com/api/v1/notifications` resulted in a `400 Bad Request` response:
{"errors":["Platforms You may only send to one delivery channel at a time. Make sure you are only including one of push... 