### PR TITLE
Migrate from legacy API keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,10 @@ your OneSignal authorization keys.
 
 ## Configuration
 
-You need to fill in your OneSignal *App ID* and *REST API Key* inside your
+You need to fill in your OneSignal *REST API URL* *App ID* and *REST API Key* inside your
 .env file like this:
 ```
+ONESIGNAL_REST_API_URL=https://api.onesignal.com
 ONESIGNAL_APP_ID=xxxxxxxxxxxxxxxxxxxx
 ONESIGNAL_REST_API_KEY=xxxxxxxxxxxxxxxxxx
 ```

--- a/config/onesignal.php
+++ b/config/onesignal.php
@@ -18,6 +18,7 @@ return array(
     |
 	|
 	*/
+    'rest_api_url' => env('ONESIGNAL_REST_API_URL', 'https://api.onesignal.com'),
     'rest_api_key' => env('ONESIGNAL_REST_API_KEY'),
     'user_auth_key' => env('USER_AUTH_KEY'),
 

--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -13,7 +13,6 @@ use GuzzleHttp\Psr7\Response as Psr7Response;
 
 class OneSignalClient
 {
-    const API_URL = "https://onesignal.com/api/v1";
 
     const ENDPOINT_NOTIFICATIONS = "/notifications";
     const ENDPOINT_PLAYERS = "/players";
@@ -22,6 +21,7 @@ class OneSignalClient
     protected $client;
     protected $headers;
     protected $appId;
+    protected $restApiUrl;
     protected $restApiKey;
     protected $userAuthKey;
     protected $additionalParams;
@@ -71,13 +71,15 @@ class OneSignalClient
 
     /**
      * @param $appId
+     * @param $restApiUrl
      * @param $restApiKey
      * @param $userAuthKey
      * @param int $guzzleClientTimeout
      */
-    public function __construct($appId, $restApiKey, $userAuthKey, $guzzleClientTimeout = 0)
+    public function __construct($appId, $restApiUrl, $restApiKey, $userAuthKey, $guzzleClientTimeout = 0)
     {
         $this->appId = $appId;
+        $this->restApiUrl = $restApiUrl;
         $this->restApiKey = $restApiKey;
         $this->userAuthKey = $userAuthKey;
 
@@ -506,29 +508,29 @@ class OneSignalClient
 
     public function post($endPoint) {
         if($this->requestAsync === true) {
-            $promise = $this->client->postAsync(self::API_URL . $endPoint, $this->headers);
+            $promise = $this->client->postAsync($this->restApiUrl . $endPoint, $this->headers);
             return (is_callable($this->requestCallback) ? $promise->then($this->requestCallback) : $promise);
         }
-        return $this->client->post(self::API_URL . $endPoint, $this->headers);
+        return $this->client->post($this->restApiUrl . $endPoint, $this->headers);
     }
 
     public function put($endPoint) {
         if($this->requestAsync === true) {
-            $promise = $this->client->putAsync(self::API_URL . $endPoint, $this->headers);
+            $promise = $this->client->putAsync($this->restApiUrl . $endPoint, $this->headers);
             return (is_callable($this->requestCallback) ? $promise->then($this->requestCallback) : $promise);
         }
-        return $this->client->put(self::API_URL . $endPoint, $this->headers);
+        return $this->client->put($this->restApiUrl . $endPoint, $this->headers);
     }
 
     public function get($endPoint) {
-        return $this->client->get(self::API_URL . $endPoint, $this->headers);
+        return $this->client->get($this->restApiUrl . $endPoint, $this->headers);
     }
 
     public function delete($endPoint) {
         if($this->requestAsync === true) {
-            $promise = $this->client->deleteAsync(self::API_URL . $endPoint, $this->headers);
+            $promise = $this->client->deleteAsync($this->restApiUrl . $endPoint, $this->headers);
             return (is_callable($this->requestCallback) ? $promise->then($this->requestCallback) : $promise);
         }
-        return $this->client->delete(self::API_URL . $endPoint, $this->headers);
+        return $this->client->delete($this->restApiUrl . $endPoint, $this->headers);
     }
 }

--- a/src/OneSignalServiceProvider.php
+++ b/src/OneSignalServiceProvider.php
@@ -36,7 +36,7 @@ class OneSignalServiceProvider extends ServiceProvider
                 $config = $app['config']['onesignal'] ?: $app['config']['onesignal::config'];
             }
 
-            return new OneSignalClient($config['app_id'], $config['rest_api_key'], $config['user_auth_key'] , $config['guzzle_client_timeout']);
+            return new OneSignalClient($config['app_id'], $config['rest_api_url'], $config['rest_api_key'], $config['user_auth_key'] , $config['guzzle_client_timeout']);
         });
 
         $this->app->alias('onesignal', 'Berkayk\OneSignal\OneSignalClient');

--- a/tests/test.php
+++ b/tests/test.php
@@ -7,6 +7,7 @@ $dotenv->load();
 
 $client = new Berkayk\OneSignal\OneSignalClient(
     getenv('APP_ID'),
+    getenv('REST_API_URL'),
     getenv('REST_API_KEY'),
     getenv('USER_AUTH_KEY'));
 


### PR DESCRIPTION
Legacy user API keys will be deprecated on the 1st of March 2025.

Documentation link from [OneSignal](https://documentation.onesignal.com/docs/keys-and-ids?_gl=1*95kqw8*_gcl_au*MTg4MjQyNDc0OC4xNzMzNzc1NTcxLjIzMDc0NTY3NS4xNzMzOTU0OTY5LjE3MzM5NTUwMTI.*_ga*NjU5NTIwNzk2LjE3MzM3NzU1Njk.*_ga_Z6LSTXWLPN*MTczMzk1NDQ5Ny4zLjEuMTczMzk1NzcxMC41MC4wLjY3NzM3MzA4OQ..#migrating-from-legacy-api-keys)

### Changes

- Added a new configuration settings for `ONESIGNAL_REST_API_URL`. For projects still using the old API keys, just update the old API url.
- Refactor the code to use the `evn` variable