### PR TITLE
Get API URL from env or pass it as optional parameter in client constructor

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -76,10 +76,10 @@ class OneSignalClient
      * @param $userAuthKey
      * @param int $guzzleClientTimeout
      */
-    public function __construct($appId, $restApiUrl, $restApiKey, $userAuthKey, $guzzleClientTimeout = 0)
+    public function __construct($appId, $restApiKey, $userAuthKey, $guzzleClientTimeout = 0, $restApiUrl = null)
     {
         $this->appId = $appId;
-        $this->restApiUrl = $restApiUrl;
+        $this->restApiUrl = $restApiUrl ?? config('onesignal.rest_api_url');
         $this->restApiKey = $restApiKey;
         $this->userAuthKey = $userAuthKey;
 


### PR DESCRIPTION
The 2.3 version had a breaking change because of an mandotary parameter in the client constructor. This PR intent to make this parameter optional, and also get the url from the env file if the parameter is not present. 
That way we can keep the retrocompatibility for anyone that update the minor patches.