### PR TITLE
fix: reorder client parameters for singleton

### DIFF
--- a/src/OneSignalServiceProvider.php
+++ b/src/OneSignalServiceProvider.php
@@ -36,7 +36,7 @@ class OneSignalServiceProvider extends ServiceProvider
                 $config = $app['config']['onesignal'] ?: $app['config']['onesignal::config'];
             }
 
-            return new OneSignalClient($config['app_id'], $config['rest_api_url'], $config['rest_api_key'], $config['user_auth_key'] , $config['guzzle_client_timeout']);
+            return new OneSignalClient($config['app_id'], $config['rest_api_key'], $config['user_auth_key'] , $config['guzzle_client_timeout'], $config['rest_api_url']);
         });
 
         $this->app->alias('onesignal', 'Berkayk\OneSignal\OneSignalClient');


### PR DESCRIPTION
[v2.3](https://github.com/berkayk/laravel-onesignal/pull/197) Changed the order of the parameters. Then in [2.4](https://github.com/berkayk/laravel-onesignal/pull/198) we fixed but I forgot to fix the singleton instantiation.

This probably could be  v2.4.1