### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/OneSignalClient.php
+++ b/src/OneSignalClient.php
@@ -93,7 +93,7 @@ class OneSignalClient
 
     private function createGuzzleHandler() {
         return tap(HandlerStack::create(new CurlHandler()), function (HandlerStack $handlerStack) {
-            $handlerStack->push(Middleware::retry(function ($retries, Psr7Request $request, Psr7Response $response = null, RequestException|ConnectException $exception = null) {
+            $handlerStack->push(Middleware::retry(function ($retries, Psr7Request $request, ?Psr7Response $response = null, RequestException|ConnectException $exception = null) {
                 if ($retries >= $this->maxRetries) {
                     return false;
                 }
@@ -476,7 +476,7 @@ class OneSignalClient
         return $this->sendPlayer($parameters, 'PUT', self::ENDPOINT_PLAYERS . '/' . $parameters['id']);
     }
 
-    public function requestPlayersCSV($app_id = null, Array $parameters = null) {
+    public function requestPlayersCSV($app_id = null, ?array $parameters = null) {
         $this->requiresAuth();
         $this->usesJSON();
 


### PR DESCRIPTION
Fix PHP 8.4 deprecations for Implicitly marking parameter as nullable is deprecated